### PR TITLE
fix: start GnuPG launchd jobs left pending by bootstrap

### DIFF
--- a/.chezmoiscripts/run_once_before_04-setup-gpg-agent.sh
+++ b/.chezmoiscripts/run_once_before_04-setup-gpg-agent.sh
@@ -48,8 +48,9 @@ if ! grep -q "^no-autostart" "$common_conf"; then
   append_config_line "$common_conf" "no-autostart"
 fi
 
-# Both daemons fork and the launched process exits: AbandonProcessGroup keeps
-# the child, KeepAlive would loop on the held socket.
+# Both daemons fork and the launched process exits (--no-detach only keeps the
+# console, it still forks in GnuPG 2.5): AbandonProcessGroup keeps the child,
+# KeepAlive would respawn a parent that exits 2 on the held socket.
 typeset -A daemons=(
   gpg-agent "$brew_prefix/bin/gpg-agent"
   keyboxd "$brew_prefix/opt/gnupg/libexec/keyboxd"
@@ -83,13 +84,20 @@ EOF
     launchctl bootout "$service"
   fi
   # bootout reaps only the exited parent; the daemon holding the socket must
-  # stop before the new instance starts.
+  # stop before the new instance starts. gpgconf --kill returns after it exited.
   "$gpgconf_bin" --kill "$component"
   launchctl bootstrap "gui/$UID" "$plist"
+  # While the gui domain is in on-demand-only mode (login app restore or Setup
+  # Assistant), bootstrap leaves the RunAtLoad spawn pended until that phase
+  # ends, long after the wait below gives up (issue #28); kickstart starts it
+  # now. Skip it once launchd reports a run: a second parent would exit 2 on
+  # the held socket and leave that exit code in the diagnostics the error
+  # below points at.
+  launchctl print "$service" | grep -q 'runs = [1-9]' || launchctl kickstart "$service"
 done
 
-# bootstrap returns before RunAtLoad spawns anything; the card commands below
-# need both sockets.
+# Neither bootstrap nor kickstart waits for the daemon's socket; the card
+# commands below need both.
 for _ in {1..50}; do
   ready=1
   for daemon_flag in "" --keyboxd; do

--- a/.chezmoiscripts/run_once_before_04-setup-gpg-agent.sh
+++ b/.chezmoiscripts/run_once_before_04-setup-gpg-agent.sh
@@ -15,15 +15,25 @@ for f in "$HOME/.gnupg"/*(.N); do
   chmod 600 "$f"
 done
 
+append_config_line() {
+  local file=$1 line=$2
+  # A hand-edited file may end without a newline; appending would glue the
+  # option onto the last line, where the `grep "^option"` guards never see it.
+  if [[ -s "$file" ]] && ! tail -c1 "$file" | read -r _; then
+    echo >> "$file"
+  fi
+  print -r -- "$line" >> "$file"
+}
+
 gpg_agent_conf="$HOME/.gnupg/gpg-agent.conf"
 [[ ! -f "$gpg_agent_conf" ]] && touch "$gpg_agent_conf"
 
 if ! grep -q "^pinentry-program" "$gpg_agent_conf"; then
-  echo "pinentry-program $pinentry_bin" >> "$gpg_agent_conf"
+  append_config_line "$gpg_agent_conf" "pinentry-program $pinentry_bin"
 fi
 # git-ssh-gpg-agent uses S.gpg-agent.ssh, which exists only with ssh support.
 if ! grep -q "^enable-ssh-support" "$gpg_agent_conf"; then
-  echo "enable-ssh-support" >> "$gpg_agent_conf"
+  append_config_line "$gpg_agent_conf" "enable-ssh-support"
 fi
 
 # no-autostart: daemons come only from the launchd jobs below (CONCEPTS.md, Bootstrap).
@@ -32,10 +42,10 @@ common_conf="$HOME/.gnupg/common.conf"
 # use-keyboxd ignores an existing pubring.kbx, so never switch a populated
 # legacy homedir.
 if [[ ! -f "$HOME/.gnupg/pubring.kbx" ]] && ! grep -q "^use-keyboxd" "$common_conf"; then
-  echo "use-keyboxd" >> "$common_conf"
+  append_config_line "$common_conf" "use-keyboxd"
 fi
 if ! grep -q "^no-autostart" "$common_conf"; then
-  echo "no-autostart" >> "$common_conf"
+  append_config_line "$common_conf" "no-autostart"
 fi
 
 # Both daemons fork and the launched process exits: AbandonProcessGroup keeps


### PR DESCRIPTION
Closes #28.

On a machine whose gui launchd domain is in on-demand-only mode, `launchctl bootstrap` registers the gpg-agent and keyboxd jobs but leaves their `RunAtLoad` spawn pending as speculative, so the bootstrap script's socket wait failed. Apple's DTS describes that mode in [LaunchAgent priority](https://developer.apple.com/forums/thread/706985): while login app restore or Setup Assistant is still running, the gui domain accepts only on-demand starts and pends every other spawn until that phase ends, so a `chezmoi init` run in that window hits it. The script now kickstarts each job unless `launchctl print` already reports a run, and appends conf options on their own line even when a hand-edited file lacks a trailing newline.

The `--no-detach` plus `KeepAlive` form suggested in the issue is not adopted: in GnuPG 2.5.22 `--no-detach` only keeps the console and the launched process still forks, so `KeepAlive` would respawn a parent that exits 2 on the held socket. `gpgconf --kill` returns after the daemon exited, so no extra wait was added.

Because the script contents changed, the next `chezmoi apply` on every existing machine reruns it: gpg-agent and keyboxd restart and the YubiKey must be present.

The on-demand-only mode could not be reproduced locally. The kickstart branch was exercised with a throwaway launchd label whose job had `RunAtLoad` false; on a normal gui domain, `launchctl bootstrap` returns with `runs = 1` already recorded, so the guard skips kickstart there. Verification on the reporter's machine is requested in the issue.
