### PR TITLE
fix: exclude Finder metadata from chezmoi targets

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,3 +1,4 @@
 **/*.test.*
+**/.DS_Store
 AGENTS.md
 Brewfile

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,4 +1,5 @@
 **/*.test.*
 **/.DS_Store
+
 AGENTS.md
 Brewfile


### PR DESCRIPTION
Fixes #35 by excluding `.DS_Store` target paths during `chezmoi add` and `apply`, including nested directories. Files added as `dot_DS_Store` are outside the existing global Git ignore rule; raw `.DS_Store` files in ordinary source directories are already ignored by chezmoi.

An isolated chezmoi v2.72.1 check confirmed that root and nested metadata files are excluded while an ordinary sibling file is still managed.
